### PR TITLE
52 make git action caches python modules

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -36,7 +36,7 @@ runs:
       id: cache-restore
       uses: actions/cache/restore@v4
       with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}
         path: .venv
     #install missing packages
     - name: Install packages
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "${{cache_restore.key}}" --confirm
+        gh actions-cache delete "${{cache-restore.key}}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
@@ -61,5 +61,5 @@ runs:
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
+        key: ${{cache_restore.key}}
         path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -44,3 +44,9 @@ runs:
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       shell: bash
+
+    # - name: Saved cached virtualenv
+    #   uses: actions/cache/save@v4
+    #   with:
+    #     key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
+    #     path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -61,5 +61,5 @@ runs:
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: ${{cache_restore.key}}
+        key: ${{steps.cache-restore.key}}
         path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -7,6 +7,9 @@ inputs:
   pip-install:
     description: Parameters to pass to pip install
     default: "$([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e .[dev]"
+  workflow:
+    description: Which workflow started this.
+    default: ""
 
 runs:
   using: composite
@@ -19,16 +22,31 @@ runs:
         fi
         echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_ENV"
       shell: bash
-
+    #Setup python env
     - name: Setup python
+      id: setup_python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-
+        #cache: "pip"
+    #Load caches if match
+    - name: Restore cached virtualenv
+      uses: actions/cache/restore@v4
+      with:
+        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles('dev-requirements.txt') }}
+        path: .venv
+    #install missing packages
     - name: Install packages
-      run: pip install ${{ inputs.pip-install }}
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        python -m pip install ${{ inputs.pip-install }}
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       shell: bash
 
-    - name: Report what was installed
-      run: pip freeze
-      shell: bash
+    - name: Saved cached virtualenv
+      uses: actions/cache/save@v4
+      with:
+        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles('dev-requirements.txt') }}
+        path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "cache_restore.key" --confirm
+        gh actions-cache delete "${{cache_restore.key}}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}" --confirm
+        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "${{steps.cache-restore.key}}" --confirm
+        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
@@ -61,5 +61,5 @@ runs:
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: ${{steps.cache-restore.key}}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}
         path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "${{cache-restore.key}}" --confirm
+        gh actions-cache delete "${{steps.cache-restore.key}}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: "$([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e .[dev]"
   workflow:
     description: Which workflow started this.
-    default: ""
+    default: "help"
 
 runs:
   using: composite
@@ -33,7 +33,7 @@ runs:
     - name: Restore cached virtualenv
       uses: actions/cache/restore@v4
       with:
-        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles('dev-requirements.txt') }}
+        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles(inputs.pip-install) }}
         path: .venv
     #install missing packages
     - name: Install packages
@@ -48,5 +48,5 @@ runs:
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles('dev-requirements.txt') }}
+        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles(inputs.pip-install) }}
         path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -12,6 +12,7 @@ inputs:
     default: "help"
   token:
     description: Git token
+    required: true
 
 runs:
   using: composite
@@ -30,13 +31,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-    #Load caches if match
-    - name: Restore cached virtualenv
-      id: cache-restore
-      uses: actions/cache/restore@v4
-      with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
-        path: .venv
+
     #install missing packages
     - name: Install packages
       run: |
@@ -46,19 +41,3 @@ runs:
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       shell: bash
-
-    - name: Delete Previous Cache
-      if: ${{ steps.cache-restore.outputs.cache-hit }}
-      continue-on-error: true
-      run: |
-        gh extension install actions/gh-actions-cache
-        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      shell: bash
-
-    - name: Saved cached virtualenv
-      uses: actions/cache/save@v4
-      with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
-        path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -28,9 +28,9 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-        #cache: "pip"
     #Load caches if match
     - name: Restore cached virtualenv
+      id: cache-restore
       uses: actions/cache/restore@v4
       with:
         key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
@@ -45,8 +45,18 @@ runs:
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       shell: bash
 
-    # - name: Saved cached virtualenv
-    #   uses: actions/cache/save@v4
-    #   with:
-    #     key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
-    #     path: .venv
+    - name: Delete Previous Cache
+      if: ${{ steps.cache-restore.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+
+    - name: Saved cached virtualenv
+      uses: actions/cache/save@v4
+      with:
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
+        path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -36,7 +36,7 @@ runs:
       id: cache-restore
       uses: actions/cache/restore@v4
       with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}
         path: .venv
     #install missing packages
     - name: Install packages
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}" --confirm
+        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
@@ -61,5 +61,5 @@ runs:
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}
         path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -41,14 +41,6 @@ runs:
         python -m venv .venv
         source .venv/bin/activate
         python -m pip install ${{ inputs.pip-install }}
-
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       shell: bash
-
-    - name: Saved cached virtualenv
-      uses: actions/cache/save@v4
-      with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
-        path: .venv
-
-        # echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
-        # echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
+        gh actions-cache delete "cache_restore.key" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -52,7 +52,7 @@ runs:
         gh extension install actions/gh-actions-cache
         gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
 
     - name: Saved cached virtualenv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -7,7 +7,7 @@ inputs:
   pip-install:
     description: Parameters to pass to pip install
     default: "$([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e .[dev]"
-  workflow:
+  workflow-name:
     description: Which workflow started this.
     default: "help"
 
@@ -33,7 +33,7 @@ runs:
     - name: Restore cached virtualenv
       uses: actions/cache/restore@v4
       with:
-        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles(inputs.pip-install) }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
         path: .venv
     #install missing packages
     - name: Install packages
@@ -41,12 +41,14 @@ runs:
         python -m venv .venv
         source .venv/bin/activate
         python -m pip install ${{ inputs.pip-install }}
-        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
-        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+
       shell: bash
 
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ inputs.workflow }}-${{ hashFiles(inputs.pip-install) }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
         path: .venv
+
+        # echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        # echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -36,7 +36,7 @@ runs:
       id: cache-restore
       uses: actions/cache/restore@v4
       with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}
         path: .venv
     #install missing packages
     - name: Install packages
@@ -53,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}" --confirm
+        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}" --confirm
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
@@ -61,5 +61,5 @@ runs:
     - name: Saved cached virtualenv
       uses: actions/cache/save@v4
       with:
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}
         path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -31,7 +31,13 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-
+    #Load caches if match
+    - name: Restore cached virtualenv
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
+        path: .venv
     #install missing packages
     - name: Install packages
       run: |
@@ -41,3 +47,19 @@ runs:
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
       shell: bash
+
+    - name: Delete Previous Cache
+      if: ${{ steps.cache-restore.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      shell: bash
+
+    - name: Saved cached virtualenv
+      uses: actions/cache/save@v4
+      with:
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
+        path: .venv

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -10,6 +10,8 @@ inputs:
   workflow-name:
     description: Which workflow started this.
     default: "help"
+  token:
+    description: Git token
 
 runs:
   using: composite
@@ -52,7 +54,7 @@ runs:
         gh extension install actions/gh-actions-cache
         gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
 
     - name: Saved cached virtualenv

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -27,7 +27,6 @@ jobs:
         run: pipx run twine check --strict dist/*
 
       - name: Install produced wheel
-        id: inputs
         uses: ./.github/actions/install_requirements
         with:
           pip-install: dist/*.whl
@@ -36,9 +35,3 @@ jobs:
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test
         run: python -m $(ls --hide='*.egg-info' src | head -1) --version
-      - name: Saved cached virtualenv
-        uses: actions/cache/save@v4
-        with:
-          key: venv-${{ runner.os }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
-          path: .venv
-  

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -25,35 +25,15 @@ jobs:
 
       - name: Check for packaging errors
         run: pipx run twine check --strict dist/*
-      #Load caches if match
-      - name: Restore cached virtualenv
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
-          path: .venv      
+          
       - name: Install produced wheel
         uses: ./.github/actions/install_requirements
         with:
           pip-install: dist/*.whl
           workflow-name: dist
-          token: secrets.GITHUB_TOKEN
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test
         run: python -m $(ls --hide='*.egg-info' src | head -1) --version
-      - name: Delete Previous Cache
-        if: ${{ steps.cache-restore.outputs.cache-hit }}
-        continue-on-error: true
-        run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-  
-      - name: Saved cached virtualenv
-        uses: actions/cache/save@v4
-        with:
-          key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
-          path: .venv
+      

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -30,6 +30,7 @@ jobs:
         uses: ./.github/actions/install_requirements
         with:
           pip-install: dist/*.whl
+          workflow-name: dist
 
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -25,7 +25,13 @@ jobs:
 
       - name: Check for packaging errors
         run: pipx run twine check --strict dist/*
-
+      #Load caches if match
+      - name: Restore cached virtualenv
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}
+          path: .venv      
       - name: Install produced wheel
         uses: ./.github/actions/install_requirements
         with:
@@ -36,4 +42,18 @@ jobs:
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test
         run: python -m $(ls --hide='*.egg-info' src | head -1) --version
-      
+      - name: Delete Previous Cache
+        if: ${{ steps.cache-restore.outputs.cache-hit }}
+        continue-on-error: true
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
+        env:
+          GITHUB_TOKEN: secrets.GITHUB_TOKEN
+        shell: bash
+  
+      - name: Saved cached virtualenv
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
+          path: .venv

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -27,6 +27,7 @@ jobs:
         run: pipx run twine check --strict dist/*
 
       - name: Install produced wheel
+        id: inputs
         uses: ./.github/actions/install_requirements
         with:
           pip-install: dist/*.whl
@@ -35,3 +36,9 @@ jobs:
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test
         run: python -m $(ls --hide='*.egg-info' src | head -1) --version
+      - name: Saved cached virtualenv
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{inputs.workflow-name}}-${{ hashFiles(inputs.pip-install) }}
+          path: .venv
+  

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           pip-install: dist/*.whl
           workflow-name: dist
+          token: secrets.GITHUB_TOKEN
 
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test
         run: python -m $(ls --hide='*.egg-info' src | head -1) --version
+      

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -49,7 +49,7 @@ jobs:
           gh extension install actions/gh-actions-cache
           gh actions-cache delete "venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.workflow-name }}-${{ hashFiles(inputs.pip-install) }}" --confirm
         env:
-          GITHUB_TOKEN: secrets.GITHUB_TOKEN
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
   
       - name: Saved cached virtualenv

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install python packages
         uses: ./.github/actions/install_requirements
         with:
-          workflow-name: dist
+          workflow-name: docs
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -21,7 +21,9 @@ jobs:
 
       - name: Install python packages
         uses: ./.github/actions/install_requirements
-
+        with:
+          workflow-name: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build docs
         run: tox -e docs
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -31,6 +31,9 @@ jobs:
       - if: inputs.python-version == 'dev'
         name: Install dev versions of python packages
         uses: ./.github/actions/install_requirements
+        with:
+          workflow-name: test
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: inputs.python-version == 'dev'
         name: Write the requirements as an artifact
@@ -49,6 +52,8 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           pip-install: ".[dev]"
+          workflow-name: test
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         run: tox -e tests

--- a/.github/workflows/_tox.yml
+++ b/.github/workflows/_tox.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install python packages
         uses: ./.github/actions/install_requirements
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tox
         run: tox -e ${{ inputs.tox }}

--- a/.github/workflows/_tox.yml
+++ b/.github/workflows/_tox.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ./.github/actions/install_requirements
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          workflow-name: tox
 
       - name: Run tox
         run: tox -e ${{ inputs.tox }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "blueapi",
     "ophyd",
     "dls-dodal",
-    "ophyd-async",
+    "ophyd-async<=0.5",
     "bluesky",
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "blueapi",
     "ophyd",
     "dls-dodal",
-    "ophyd-async<=0.5",
+    "ophyd-async",
     "bluesky",
 
 


### PR DESCRIPTION
fix #52 

Git action will try to use the cached python environment each time, install anything that missing and overwrite the caches, giving a small boost in git action speed but at the cost of about 500Mb per cache.
